### PR TITLE
fix: model hmr works only once

### DIFF
--- a/src/hot.dev.js
+++ b/src/hot.dev.js
@@ -176,7 +176,9 @@ function patchAppStart(inst) {
         },
       })
     }
-    return oldStart.call(inst, container)
+    const rootElement = oldStart.call(inst, container)
+    patchAppModel(inst)
+    return rootElement
   }
 }
 


### PR DESCRIPTION
修复在 app.start 后 model 只能成功替换一次的问题。
原因在于 app.start 后会重新赋值 app.model，但是里面却是直接引用原生的 model 方法。